### PR TITLE
Introduce ProducerConfig & make keyFunc optional

### DIFF
--- a/kafka/example/example.go
+++ b/kafka/example/example.go
@@ -54,7 +54,7 @@ func (m MyMessage) Marshal() ([]byte, error) {
 func produce() {
 
 	sink, err := kafka.NewMessageSink(
-		kafka.KafkaSinkConfig{
+		kafka.SinkConfig{
 			Topic:   "demo-topic",
 			Brokers: []string{"localhost:9092"},
 			KeyFunc: func(m pubsub.ProducerMessage) []byte {

--- a/kafka/kafkasink.go
+++ b/kafka/kafkasink.go
@@ -20,13 +20,13 @@ type messageSink struct {
 	closed   bool
 }
 
-type KafkaSinkConfig struct {
+type SinkConfig struct {
 	Topic   string
 	Brokers []string
 	KeyFunc func(pubsub.ProducerMessage) []byte
 }
 
-func NewMessageSink(config KafkaSinkConfig) (pubsub.MessageSink, error) {
+func NewMessageSink(config SinkConfig) (pubsub.MessageSink, error) {
 
 	conf := sarama.NewConfig()
 	conf.Producer.RequiredAcks = sarama.WaitForAll


### PR DESCRIPTION
In order to avoid further future API breakage when adding new
configuration options to the kafka producer API, introduce a
KafkaProducerConfig struct.

Also, make keyFunc optional and if not provided, use round-robin
partitioning instead of hash based.