### PR TITLE
Fix for newer sarama version

### DIFF
--- a/kafka/kafkasink.go
+++ b/kafka/kafkasink.go
@@ -30,6 +30,9 @@ func NewMessageSink(config MessageSinkConfig) (pubsub.MessageSink, error) {
 
 	conf := sarama.NewConfig()
 	conf.Producer.RequiredAcks = sarama.WaitForAll
+	conf.Producer.Return.Successes = true
+	conf.Producer.Return.Errors = true
+
 	if config.KeyFunc != nil {
 		conf.Producer.Partitioner = sarama.NewHashPartitioner
 	} else {


### PR DESCRIPTION
Set config parameters, as we should have all along, to ensure we work
with recent (stricter?) sarama lib