### PR TITLE
Simplify MessageSource based on user feedback

### DIFF
--- a/amqp/example/example.go
+++ b/amqp/example/example.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -26,35 +27,25 @@ func main() {
 		Message:    fmt.Sprintf("hello. it is currently %v", time.Now()),
 	})
 
-	defer sink.Close()
-
 	cons := amqp.NewMessageSource(amqp.MessageSourceConfig{
 		Address:       "amqp://localhost:5672/",
 		ConsumerGroup: "demo-group",
 		Topic:         "demo-topic",
 	})
 
-	// consume messages
-	go func() {
+	// consume messages for 2 seconds
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
 
-		handler := func(m pubsub.ConsumerMessage) error {
-			fmt.Printf("message is: %s\n", m.Data)
-			return nil
-		}
+	handler := func(m pubsub.ConsumerMessage) error {
+		fmt.Printf("message is: %s\n", m.Data)
+		return nil
+	}
 
-		onError := func(m pubsub.ConsumerMessage, e error) error {
-			panic("unexpected error")
-		}
+	onError := func(m pubsub.ConsumerMessage, e error) error {
+		panic("unexpected error")
+	}
 
-		if err := cons.ConsumeMessages(handler, onError); err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	// consume for 2 seconds, then close
-	time.Sleep(2 * time.Second)
-
-	if err := cons.Close(); err != nil {
+	if err := cons.ConsumeMessages(ctx, handler, onError); err != nil {
 		log.Fatal(err)
 	}
 

--- a/kafka/example/example.go
+++ b/kafka/example/example.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -20,27 +21,19 @@ func main() {
 		Zookeepers:    []string{"localhost:2181"},
 	})
 
-	// consume messages
-	go func() {
+	// consume messages for 2 seconds
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
 
-		handler := func(m pubsub.ConsumerMessage) error {
-			fmt.Printf("message is: %s\n", m.Data)
-			return nil
-		}
+	handler := func(m pubsub.ConsumerMessage) error {
+		fmt.Printf("message is: %s\n", m.Data)
+		return nil
+	}
 
-		onError := func(m pubsub.ConsumerMessage, e error) error {
-			panic("unexpected error")
-		}
+	onError := func(m pubsub.ConsumerMessage, e error) error {
+		panic("unexpected error")
+	}
 
-		if err := cons.ConsumeMessages(handler, onError); err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	// consume for 2 seconds, then close
-	time.Sleep(2 * time.Second)
-
-	if err := cons.Close(); err != nil {
+	if err := cons.ConsumeMessages(ctx, handler, onError); err != nil {
 		log.Fatal(err)
 	}
 

--- a/mockqueue/mockqueue.go
+++ b/mockqueue/mockqueue.go
@@ -1,7 +1,7 @@
 package mockqueue
 
 import (
-	"errors"
+	"context"
 
 	"github.com/utilitywarehouse/go-pubsub"
 )
@@ -30,11 +30,10 @@ func (mq *MockQueue) PutMessage(m pubsub.ProducerMessage) error {
 	return nil
 }
 
-func (mq *MockQueue) ConsumeMessages(handler pubsub.ConsumerMessageHandler, onError pubsub.ConsumerErrorHandler) error {
+func (mq *MockQueue) ConsumeMessages(ctx context.Context, handler pubsub.ConsumerMessageHandler, onError pubsub.ConsumerErrorHandler) error {
 	for {
 		select {
-		case <-mq.close:
-			close(mq.closed)
+		case <-ctx.Done():
 			return nil
 		case m := <-mq.q:
 			cm := pubsub.ConsumerMessage{m}
@@ -49,11 +48,6 @@ func (mq *MockQueue) ConsumeMessages(handler pubsub.ConsumerMessageHandler, onEr
 }
 
 func (mq *MockQueue) Close() error {
-	select {
-	case <-mq.closed:
-		return errors.New("Already closed")
-	case mq.close <- struct{}{}:
-		<-mq.closed
-		return nil
-	}
+	// no-op in mock.
+	return nil
 }

--- a/nats/example/example.go
+++ b/nats/example/example.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -16,29 +17,23 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// consume messages
 	go func() {
-
-		handler := func(m pubsub.ConsumerMessage) error {
-			fmt.Printf("message is: %s\n", m.Data)
-			return nil
-		}
-
-		onError := func(m pubsub.ConsumerMessage, e error) error {
-			panic("unexpected error")
-		}
-
-		if err := cons.ConsumeMessages(handler, onError); err != nil {
-			log.Fatal(err)
-		}
+		time.Sleep(1 * time.Second)
+		produce()
 	}()
+	// consume messages
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
 
-	produce()
+	handler := func(m pubsub.ConsumerMessage) error {
+		fmt.Printf("message is: %s\n", m.Data)
+		return nil
+	}
 
-	// consume for 2 seconds, then close
-	time.Sleep(2 * time.Second)
+	onError := func(m pubsub.ConsumerMessage, e error) error {
+		panic("unexpected error")
+	}
 
-	if err := cons.Close(); err != nil {
+	if err := cons.ConsumeMessages(ctx, handler, onError); err != nil {
 		log.Fatal(err)
 	}
 

--- a/natss/example/example.go
+++ b/natss/example/example.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -13,36 +14,26 @@ func main() {
 
 	produce()
 
-	cons, err := nats.NewMessageSource("cluster-id", "demo-topic", "consumer-02", "nats://localhost:4222")
+	cons, err := nats.NewMessageSource("nats://localhost:4222", "cluster-id", "consumer-02", "demo-topic")
 	if err != nil {
 		panic(err)
 		log.Fatal(err)
 	}
 
-	// consume messages
-	go func() {
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
 
-		handler := func(m pubsub.ConsumerMessage) error {
-			fmt.Printf("message is: %s\n", m.Data)
-			return nil
-		}
-
-		onError := func(m pubsub.ConsumerMessage, e error) error {
-			panic("unexpected error")
-		}
-
-		if err := cons.ConsumeMessages(handler, onError); err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	// consume for 2 seconds, then close
-	time.Sleep(2 * time.Second)
-
-	if err := cons.Close(); err != nil {
-		log.Fatal(err)
+	handler := func(m pubsub.ConsumerMessage) error {
+		fmt.Printf("message is: %s\n", m.Data)
+		return nil
 	}
 
+	onError := func(m pubsub.ConsumerMessage, e error) error {
+		panic("unexpected error")
+	}
+
+	if err := cons.ConsumeMessages(ctx, handler, onError); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func produce() {

--- a/pubsub.go
+++ b/pubsub.go
@@ -1,6 +1,7 @@
 package pubsub
 
 import (
+	"context"
 	"io"
 )
 
@@ -27,9 +28,8 @@ type MessageSink interface {
 }
 
 type MessageSource interface {
-	io.Closer
-	// Consume messages will block until the source is closed
-	ConsumeMessages(handler ConsumerMessageHandler, onError ConsumerErrorHandler) error
+	// Consume messages will block until error or until the context is done.
+	ConsumeMessages(ctx context.Context, handler ConsumerMessageHandler, onError ConsumerErrorHandler) error
 }
 
 // ConsumerMessageHandler processes messages, and should return an error if it


### PR DESCRIPTION
The MessageSource interface design made is hard to deal with a variety
of error cases elegantly. ConsumeMessages was blocking, and to exit the
consumption loop, the caller had to call Close() concurrently.
It was never clear whether the lifecycle of the consumption process
lived with with the ConsumeMessages call, or the MessageSource instance
this was confusing.  It also meant that the caller had to know that the
MessageSource was effectively closed when exiting on error, even though
Close() was never called explicitly.

This has been simplified to use the new standard context.Context
mechanism for exiting ConsumeMessages().  The Close() method has gone
from MessageSource.

Unfortunately, this is an API change, but can simplify message
consumption code significantly.