### PR TITLE
Remove "deprecated" ZK based API.

### DIFF
--- a/kafka/kafka_test.go
+++ b/kafka/kafka_test.go
@@ -23,22 +23,6 @@ func TestMain(m *testing.M) {
 	os.Exit(result)
 }
 
-func TestNewMessageSourceBackwardsCompatible(t *testing.T) {
-	cons := NewMessageSource(MessageSourceConfig{ConsumerGroup: "test-group", Topic: "topic", Zookeepers: []string{"localhost:9092"}}).(*messageSource)
-	if cons.consumergroup != "test-group" {
-		t.Error("unexpected consumer group")
-	}
-	if cons.topic != "topic" {
-		t.Error("unexpected topic")
-	}
-	if cons.brokers[0] != "localhost:9092" {
-		t.Error("unexpected brokers")
-	}
-	if cons.offset != OffsetLatest {
-		t.Error("unexpected offset")
-	}
-}
-
 func TestNewMessageSource(t *testing.T) {
 	cons := NewMessageSource(MessageSourceConfig{ConsumerGroup: "test-group", Topic: "topic", Brokers: []string{"localhost:9092"}, Offset: OffsetOldest}).(*messageSource)
 	if cons.consumergroup != "test-group" {

--- a/kafka/kafkasource.go
+++ b/kafka/kafkasource.go
@@ -25,17 +25,11 @@ type messageSource struct {
 type MessageSourceConfig struct {
 	ConsumerGroup string
 	Topic         string
-	//Deprecated: use Brokers instead
-	Zookeepers []string
-	Brokers    []string
-	Offset     int64
+	Brokers       []string
+	Offset        int64
 }
 
 func NewMessageSource(config MessageSourceConfig) pubsub.MessageSource {
-	brokers := config.Brokers
-	if brokers == nil {
-		brokers = config.Zookeepers
-	}
 
 	offset := OffsetLatest
 	if config.Offset != 0 {
@@ -45,7 +39,7 @@ func NewMessageSource(config MessageSourceConfig) pubsub.MessageSource {
 	return &messageSource{
 		consumergroup: config.ConsumerGroup,
 		topic:         config.Topic,
-		brokers:       brokers,
+		brokers:       config.Brokers,
 		offset:        offset,
 	}
 }


### PR DESCRIPTION
It is broken already and we shouldn't be using it. Also, we are allowed
since the API is not declared stable at this point.