### PR TITLE
Allowing creation of multiple instrumented sinks/sources

### DIFF
--- a/instrumented/instrumented_pubsub_test.go
+++ b/instrumented/instrumented_pubsub_test.go
@@ -63,3 +63,27 @@ func TestInstrumentation(t *testing.T) {
 		}
 	}
 }
+
+func TestInstrumentationSameCollector(t *testing.T) {
+	q := mockqueue.NewMockQueue()
+	var sink = q
+	var source = q
+
+	instrumented.NewMessageSink(sink, prometheus.CounterOpts{
+		Help: "help_sink",
+		Name: "test_sink",
+	}, "test_topic")
+	instrumented.NewMessageSink(sink, prometheus.CounterOpts{
+		Help: "help_sink",
+		Name: "test_sink",
+	}, "test_topic1")
+
+	instrumented.NewMessageSource(source, prometheus.CounterOpts{
+		Help: "help_source",
+		Name: "test_source",
+	}, "test_topic")
+	instrumented.NewMessageSource(source, prometheus.CounterOpts{
+		Help: "help_source",
+		Name: "test_source",
+	}, "test_topic1")
+}


### PR DESCRIPTION
Allowing creation of multiple instrumented sinks/sources with the same metric name

This is useful when a service writes/consumes from different topics as you end up with one metric and use the topic label to filter