### PR TITLE
Remove backoff and deadletter types

### DIFF
--- a/consumer/backoff/backoff.go
+++ b/consumer/backoff/backoff.go
@@ -1,16 +1,14 @@
 package backoff
 
 import (
-	"github.com/utilitywarehouse/go-pubsub"
 	"math"
 	"time"
+
+	"github.com/utilitywarehouse/go-pubsub"
 )
 
-// ExponentialBackOffRetryingErrorHandler a retying ConsumerErrorHandler with ExponentialBackOff
-type ExponentialBackOffRetryingErrorHandler pubsub.ConsumerErrorHandler
-
 // New returns a new ExponentialBackOffRetryingErrorHandler
-func New(handler pubsub.ConsumerMessageHandler, retries int) ExponentialBackOffRetryingErrorHandler {
+func New(handler pubsub.ConsumerMessageHandler, retries int) pubsub.ConsumerErrorHandler {
 	return NewWithFallback(
 		handler,
 		func(msg pubsub.ConsumerMessage, err error) error {
@@ -21,7 +19,7 @@ func New(handler pubsub.ConsumerMessageHandler, retries int) ExponentialBackOffR
 }
 
 // NewWithFallback returns a new ExponentialBackOffRetryingErrorHandler with fallback
-func NewWithFallback(handler pubsub.ConsumerMessageHandler, errHandler pubsub.ConsumerErrorHandler, retries int) ExponentialBackOffRetryingErrorHandler {
+func NewWithFallback(handler pubsub.ConsumerMessageHandler, errHandler pubsub.ConsumerErrorHandler, retries int) pubsub.ConsumerErrorHandler {
 	return func(msg pubsub.ConsumerMessage, err error) error {
 		for i := 0; i < retries; i++ {
 			err := handler(msg)

--- a/consumer/deadletter/deadletter.go
+++ b/consumer/deadletter/deadletter.go
@@ -16,9 +16,8 @@ type FailedConsumerMessage struct {
 	Timestamp    time.Time `json:"timestamp"`
 }
 
-// New returns a new JSONDeadLetteringErrorHandler
+// New returns a new ConsumerErrorHandler which produces JSON serialized FailedConsumerMessage to sink
 func New(sink pubsub.MessageSink, messageTopic string) pubsub.ConsumerErrorHandler {
-
 	return NewWithFallback(
 		sink,
 		func(msg pubsub.ConsumerMessage, err error) error {
@@ -28,7 +27,7 @@ func New(sink pubsub.MessageSink, messageTopic string) pubsub.ConsumerErrorHandl
 	)
 }
 
-// NewWithFallback returns a new JSONDeadLetteringErrorHandler with fallback
+// NewWithFallback returns a new ConsumerErrorHandler which produces JSON serialized FailedConsumerMessage to sink with fallback handler
 func NewWithFallback(sink pubsub.MessageSink, errHandler pubsub.ConsumerErrorHandler, messageTopic string) pubsub.ConsumerErrorHandler {
 	return func(msg pubsub.ConsumerMessage, err error) error {
 		failedMsg := FailedConsumerMessage{

--- a/consumer/deadletter/deadletter.go
+++ b/consumer/deadletter/deadletter.go
@@ -3,12 +3,10 @@ package deadletter
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/utilitywarehouse/go-pubsub"
 	"time"
-)
 
-// DeadLetteringErrorHandler a dead lettering ConsumerErrorHandler
-type JSONDeadLetteringErrorHandler pubsub.ConsumerErrorHandler
+	"github.com/utilitywarehouse/go-pubsub"
+)
 
 // FailedConsumerMessage a struct for storing failed consumer messages
 type FailedConsumerMessage struct {
@@ -19,7 +17,8 @@ type FailedConsumerMessage struct {
 }
 
 // New returns a new JSONDeadLetteringErrorHandler
-func New(sink pubsub.MessageSink, messageTopic string) JSONDeadLetteringErrorHandler {
+func New(sink pubsub.MessageSink, messageTopic string) pubsub.ConsumerErrorHandler {
+
 	return NewWithFallback(
 		sink,
 		func(msg pubsub.ConsumerMessage, err error) error {
@@ -30,7 +29,7 @@ func New(sink pubsub.MessageSink, messageTopic string) JSONDeadLetteringErrorHan
 }
 
 // NewWithFallback returns a new JSONDeadLetteringErrorHandler with fallback
-func NewWithFallback(sink pubsub.MessageSink, errHandler pubsub.ConsumerErrorHandler, messageTopic string) JSONDeadLetteringErrorHandler {
+func NewWithFallback(sink pubsub.MessageSink, errHandler pubsub.ConsumerErrorHandler, messageTopic string) pubsub.ConsumerErrorHandler {
 	return func(msg pubsub.ConsumerMessage, err error) error {
 		failedMsg := FailedConsumerMessage{
 			Message:      msg.Data,


### PR DESCRIPTION
This simplifies creating new back off retrying and dead letter handlers.
```
source.ConsumeMessages(ctx, handler, pubsub.ConsumerErrorHandler(backoff.New(handler, 3)))
```
becomes:
```
source.ConsumeMessages(ctx, handler, backoff.New(handler, 3))
```