### PR TITLE
Add SQS sink/source

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Current implementations and their status
 | Nats                                     | incomplete    |
 | Nats (streaming)                         | incomplete    |
 | AMQP                                     | incomplete    |
+| AWS SQS                                  | beta          |
 
 
 The API is not yet guaranteed but changes should be minimal from now.

--- a/sqs/example/sink.go
+++ b/sqs/example/sink.go
@@ -6,27 +6,52 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	awsSQS "github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/utilitywarehouse/go-pubsub/sqs"
 )
 
-func sinkExample() {
-	// create a queue first
+// This is an example struct that satisfies pubsub.ProducerMessage interface.
+// You'd have to create a struct in your application that satisfies this interface.
+type myMessage struct {
+	data string
+}
+
+// setting up SQS client is the same for both sink and source
+func getClient() *awsSQS.SQS {
 	creds := credentials.NewStaticCredentials("accessKey", "secretKey", "")
 	p := session.Must(session.NewSession())
 	cfg := aws.NewConfig().WithCredentials(creds).WithRegion("eu-west-1")
 
-	queue := sqs.NewQueue(p, cfg, "https://sqs.eu-west-1.amazonaws.com/123/queueName")
+	return awsSQS.New(p, cfg)
+}
 
-	// then the sinker
-	sink := sqs.NewSink(queue)
+func sinkExample() {
+	queueURL := "https://sqs.eu-west-1.amazonaws.com/123/queueName"
 
-	// create your sqs message
-	msg := sqs.Message{
-		Message: "some payload",
+	// create message sink passing AWS SQS client
+	sink, err := sqs.NewMessageSink(sqs.MessageSinkConfig{
+		Client:   getClient(),
+		QueueURL: &queueURL,
+	})
+
+	if err != nil {
+		log.Panicf("failed to create sqs sink: %v", err)
 	}
+
+	// Although this doesn't close an actual connection, it is available in the API and
+	// can act as a safeguard to prevent you from writing messages to a closed SQS sink.
+	// NOTE: We use panic in this example and not Fatal to ensure defer is called.
+	defer sink.Close()
+
+	// Create your sqs message (struct must satisfy pubsub.ProducerMessage interface).
+	msg := myMessage{data: "some payload"}
 
 	// and sink it
 	if err := sink.PutMessage(&msg); err != nil {
-		log.Fatalf("failed to sink in SQS: %v", err)
+		log.Panicf("failed to sink in SQS: %v", err)
 	}
+}
+
+func (m *myMessage) Marshal() ([]byte, error) {
+	return []byte(m.data), nil
 }

--- a/sqs/example/sink.go
+++ b/sqs/example/sink.go
@@ -3,12 +3,20 @@ package example
 import (
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/utilitywarehouse/go-pubsub/sqs"
 )
 
 func sinkExample() {
 	// create a queue first
-	queue := sqs.NewSinkQueue("accessKey", "secretKey", "eu-west-1", "https://sqs.eu-west-1.amazonaws.com/123/queueName")
+	creds := credentials.NewStaticCredentials("accessKey", "secretKey", "")
+	p := session.Must(session.NewSession())
+	cfg := aws.NewConfig().WithCredentials(creds).WithRegion("eu-west-1")
+
+	queue := sqs.NewQueue(p, cfg, "https://sqs.eu-west-1.amazonaws.com/123/queueName")
+
 	// then the sinker
 	sink := sqs.NewSink(queue)
 

--- a/sqs/example/sink.go
+++ b/sqs/example/sink.go
@@ -1,0 +1,24 @@
+package example
+
+import (
+	"log"
+
+	"github.com/utilitywarehouse/go-pubsub/sqs"
+)
+
+func sinkExample() {
+	// create a queue first
+	queue := sqs.NewSinkQueue("accessKey", "secretKey", "eu-west-1", "https://sqs.eu-west-1.amazonaws.com/123/queueName")
+	// then the sinker
+	sink := sqs.NewSink(queue)
+
+	// create your sqs message
+	msg := sqs.Message{
+		Message: "some payload",
+	}
+
+	// and sink it
+	if err := sink.PutMessage(&msg); err != nil {
+		log.Fatalf("failed to sink in SQS: %v", err)
+	}
+}

--- a/sqs/example/source.go
+++ b/sqs/example/source.go
@@ -14,6 +14,10 @@ func consumerExample() {
 	// then the consumer
 	consumer := sqs.NewConsumer(queue)
 
+	// Optionally set how long you want to wait between API poll requests (in seconds).
+	// Defaults to 0 (disabled) if not set.
+	consumer.WaitSeconds = 1
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -25,8 +29,7 @@ func consumerExample() {
 
 	// Will poll for messages and if you need to stop the loop, call cancel()
 	// to cancel the context.
-	err := consumer.ConsumeMessages(ctx, handler, errHandler)
-	if err != nil {
+	if err := consumer.ConsumeMessages(ctx, handler, errHandler); err != nil {
 		log.Fatalf("failed to consume from SQS: %v", err)
 	}
 }

--- a/sqs/example/source.go
+++ b/sqs/example/source.go
@@ -4,13 +4,21 @@ import (
 	"context"
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 	pubsub "github.com/utilitywarehouse/go-pubsub"
 	"github.com/utilitywarehouse/go-pubsub/sqs"
 )
 
 func consumerExample() {
 	// create a queue first
-	queue := sqs.NewConsumerQueue("accessKey", "secretKey", "eu-west-1", "https://sqs.eu-west-1.amazonaws.com/123/queueName")
+	creds := credentials.NewStaticCredentials("accessKey", "secretKey", "")
+	p := session.Must(session.NewSession())
+	cfg := aws.NewConfig().WithCredentials(creds).WithRegion("eu-west-1")
+
+	queue := sqs.NewQueue(p, cfg, "https://sqs.eu-west-1.amazonaws.com/123/queueName")
+
 	// then the consumer
 	consumer := sqs.NewConsumer(queue)
 

--- a/sqs/example/source.go
+++ b/sqs/example/source.go
@@ -2,42 +2,67 @@ package example
 
 import (
 	"context"
+	"encoding/json"
 	"log"
+	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pkg/errors"
 	pubsub "github.com/utilitywarehouse/go-pubsub"
 	"github.com/utilitywarehouse/go-pubsub/sqs"
 )
 
+// Message struct represents an SQS message with json tags in order to unmarshal it.
+// Make sure struct fields are exported so unmarshalling can assign values.
+type Message struct {
+	Type             string     `json:"Type"`
+	MessageID        string     `json:"MessageId"`
+	TopicArn         string     `json:"TopicArn"`
+	Subject          string     `json:"Subject"`
+	Message          string     `json:"Message"`
+	Timestamp        *time.Time `json:"Timestamp"`
+	SignatureVersion string     `json:"SignatureVersion"`
+	Signature        string     `json:"Signature"`
+	SigningCertURL   string     `json:"SigningCertURL"`
+	UnsubscribeURL   string     `json:"UnsubscribeURL"`
+}
+
 func consumerExample() {
-	// create a queue first
-	creds := credentials.NewStaticCredentials("accessKey", "secretKey", "")
-	p := session.Must(session.NewSession())
-	cfg := aws.NewConfig().WithCredentials(creds).WithRegion("eu-west-1")
+	source, err := sqs.NewMessageSource(sqs.MessageSourceConfig{
+		Client:   getClient(), // defined in sink.go
+		QueueURL: "https://sqs.eu-west-1.amazonaws.com/123/queueName",
+		// Optionally set how long you want to wait between API poll requests (in seconds).
+		// Defaults to 0 (disabled) if not set.
+		WaitSeconds: 1,
+	})
 
-	queue := sqs.NewQueue(p, cfg, "https://sqs.eu-west-1.amazonaws.com/123/queueName")
-
-	// then the consumer
-	consumer := sqs.NewConsumer(queue)
-
-	// Optionally set how long you want to wait between API poll requests (in seconds).
-	// Defaults to 0 (disabled) if not set.
-	consumer.WaitSeconds = 1
+	if err != nil {
+		log.Fatalf("failed to get SQS source: %v", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// handler will handle messages from sqs. Add your message handling logic here.
-	handler := func(pubsub.ConsumerMessage) error { return nil }
-
-	// errHandler will be called if handler fails. Add your error handling logic here.
-	errHandler := func(pubsub.ConsumerMessage, error) error { return nil }
-
-	// Will poll for messages and if you need to stop the loop, call cancel()
-	// to cancel the context.
-	if err := consumer.ConsumeMessages(ctx, handler, errHandler); err != nil {
+	// Poll for messages. To stop the loop, call `cancel()` and it will cancel the context.
+	if err := source.ConsumeMessages(ctx, msgHandler, errHandler); err != nil {
 		log.Fatalf("failed to consume from SQS: %v", err)
 	}
+}
+
+// msgHandler will process messages from SQS.
+func msgHandler(msg pubsub.ConsumerMessage) error {
+	var sqsMsg Message
+	if err := json.Unmarshal(msg.Data, sqsMsg); err != nil {
+		return errors.Wrap(err, "failed to unmarshal SQS message")
+	}
+
+	// Add your message handling logic here.
+
+	return nil
+}
+
+// errHandler will be called if message handler fails.
+func errHandler(pubsub.ConsumerMessage, error) error {
+	// Add your error handling logic here.
+
+	return nil
 }

--- a/sqs/example/source.go
+++ b/sqs/example/source.go
@@ -2,29 +2,11 @@ package example
 
 import (
 	"context"
-	"encoding/json"
 	"log"
-	"time"
 
-	"github.com/pkg/errors"
 	pubsub "github.com/utilitywarehouse/go-pubsub"
 	"github.com/utilitywarehouse/go-pubsub/sqs"
 )
-
-// Message struct represents an SQS message with json tags in order to unmarshal it.
-// Make sure struct fields are exported so unmarshalling can assign values.
-type Message struct {
-	Type             string     `json:"Type"`
-	MessageID        string     `json:"MessageId"`
-	TopicArn         string     `json:"TopicArn"`
-	Subject          string     `json:"Subject"`
-	Message          string     `json:"Message"`
-	Timestamp        *time.Time `json:"Timestamp"`
-	SignatureVersion string     `json:"SignatureVersion"`
-	Signature        string     `json:"Signature"`
-	SigningCertURL   string     `json:"SigningCertURL"`
-	UnsubscribeURL   string     `json:"UnsubscribeURL"`
-}
 
 func consumerExample() {
 	source, err := sqs.NewMessageSource(sqs.MessageSourceConfig{
@@ -50,11 +32,6 @@ func consumerExample() {
 
 // msgHandler will process messages from SQS.
 func msgHandler(msg pubsub.ConsumerMessage) error {
-	var sqsMsg Message
-	if err := json.Unmarshal(msg.Data, sqsMsg); err != nil {
-		return errors.Wrap(err, "failed to unmarshal SQS message")
-	}
-
 	// Add your message handling logic here.
 
 	return nil

--- a/sqs/example/source.go
+++ b/sqs/example/source.go
@@ -1,0 +1,32 @@
+package example
+
+import (
+	"context"
+	"log"
+
+	pubsub "github.com/utilitywarehouse/go-pubsub"
+	"github.com/utilitywarehouse/go-pubsub/sqs"
+)
+
+func consumerExample() {
+	// create a queue first
+	queue := sqs.NewConsumerQueue("accessKey", "secretKey", "eu-west-1", "https://sqs.eu-west-1.amazonaws.com/123/queueName")
+	// then the consumer
+	consumer := sqs.NewConsumer(queue)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// handler will handle messages from sqs. Add your message handling logic here.
+	handler := func(pubsub.ConsumerMessage) error { return nil }
+
+	// errHandler will be called if handler fails. Add your error handling logic here.
+	errHandler := func(pubsub.ConsumerMessage, error) error { return nil }
+
+	// Will poll for messages and if you need to stop the loop, call cancel()
+	// to cancel the context.
+	err := consumer.ConsumeMessages(ctx, handler, errHandler)
+	if err != nil {
+		log.Fatalf("failed to consume from SQS: %v", err)
+	}
+}

--- a/sqs/sink.go
+++ b/sqs/sink.go
@@ -1,0 +1,72 @@
+package sqs
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	pubsub "github.com/utilitywarehouse/go-pubsub"
+)
+
+// Sink holds SQS dependency and other flags that are necessary to identify its status.
+type Sink struct {
+	queue   QueueSink
+	sinkErr error // holds error when SQS poll failed
+	lk      sync.Mutex
+	closed  bool
+}
+
+// NewSink is the constructor returning a *Sink.
+func NewSink(queue QueueSink) *Sink {
+	return &Sink{queue: queue}
+}
+
+// PutMessage publishes a sqs.Message to SQS.
+func (s *Sink) PutMessage(msg pubsub.ProducerMessage) error {
+	if s.closed {
+		return errors.New("sqs connection closed")
+	}
+
+	// this is needed to mark status as healthy if a temporary issue is resolved
+	s.sinkErr = nil
+
+	marshalledMsg, err := msg.Marshal()
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal sqs message: %+v", msg)
+	}
+
+	payload := string(marshalledMsg)
+	if err := s.queue.SendMessage(&payload); err != nil {
+		s.sinkErr = err
+		return errors.Wrap(err, "failed to sink message in sqs")
+	}
+
+	return nil
+}
+
+// Status reports whether sink is healthy or not. Instead of doing API requests
+// we wait for SendMessage to fail to degrade the status.
+func (s *Sink) Status() (*pubsub.Status, error) {
+	status := pubsub.Status{Working: true}
+	if s.sinkErr != nil {
+		status.Working = false
+		status.Problems = append(status.Problems, s.sinkErr.Error())
+	}
+
+	return &status, nil
+}
+
+// Close is added to satisfy MessageSink interface.
+func (s *Sink) Close() error {
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	if s.closed {
+		return errors.New("Already closed")
+	}
+
+	// there's no connection to close, so we set closed flag to true and
+	// prevent sending messages to SQS.
+	s.closed = true
+
+	return nil
+}

--- a/sqs/sink.go
+++ b/sqs/sink.go
@@ -79,7 +79,7 @@ func (s *messageSink) Close() error {
 	defer s.lk.Unlock()
 
 	if s.closed {
-		return errors.New("Already closed")
+		return errors.New("already closed")
 	}
 
 	// there's no connection to close, so we set closed flag to true and

--- a/sqs/sink.go
+++ b/sqs/sink.go
@@ -9,15 +9,15 @@ import (
 
 // Sink holds SQS dependency and other flags that are necessary to identify its status.
 type Sink struct {
-	queue   QueueSink
+	q       queue
 	sinkErr error // holds error when SQS poll failed
 	lk      sync.Mutex
 	closed  bool
 }
 
 // NewSink is the constructor returning a *Sink.
-func NewSink(queue QueueSink) *Sink {
-	return &Sink{queue: queue}
+func NewSink(q queue) *Sink {
+	return &Sink{q: q}
 }
 
 // PutMessage publishes a sqs.Message to SQS.
@@ -35,7 +35,7 @@ func (s *Sink) PutMessage(msg pubsub.ProducerMessage) error {
 	}
 
 	payload := string(marshalledMsg)
-	if err := s.queue.SendMessage(&payload); err != nil {
+	if err := s.q.SendMessage(&payload); err != nil {
 		s.sinkErr = err
 		return errors.Wrap(err, "failed to sink message in sqs")
 	}

--- a/sqs/sink_test.go
+++ b/sqs/sink_test.go
@@ -139,8 +139,8 @@ func Test_PutMessageAlreadyClosed_Fail(t *testing.T) {
 		t.Fatalf("expected error about already closed connection")
 	}
 
-	if !strings.Contains(err.Error(), "Already closed") {
-		t.Errorf("expected Already closed error, got: %v", err)
+	if !strings.Contains(err.Error(), "already closed") {
+		t.Errorf("expected closed error, got: %v", err)
 	}
 }
 

--- a/sqs/sink_test.go
+++ b/sqs/sink_test.go
@@ -1,0 +1,119 @@
+package sqs_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/utilitywarehouse/go-pubsub/sqs"
+)
+
+func Test_PutMessage_Success(t *testing.T) {
+	s := sqs.NewSink(&mockSink{})
+	msg := sqs.Message{Message: "test string"}
+	if err := s.PutMessage(&msg); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func Test_PutMessageSinkClosed_Fail(t *testing.T) {
+	s := sqs.NewSink(&mockSink{})
+	if err := s.Close(); err != nil {
+		t.Fatalf("unexpected error while closing sink: %v", err)
+	}
+
+	err := s.PutMessage(&sqs.Message{})
+	if !strings.Contains(err.Error(), "sqs connection closed") {
+		t.Errorf("expected error about closed connection, got: %v", err)
+	}
+}
+
+func Test_PutMessageInvalid_Fail(t *testing.T) {
+	fakeErr := errors.New("fake error")
+	s := sqs.NewSink(&mockSink{})
+
+	err := s.PutMessage(&mockMessage{err: fakeErr})
+	if err == nil {
+		t.Fatalf("expected marshalling error, got: <nil>")
+	}
+
+	if errors.Cause(err) != fakeErr {
+		t.Errorf("expected fake error, got: %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "failed to marshal sqs message") {
+		t.Errorf("expected failed marshalling error, got: %v", err)
+	}
+
+	st, err := s.Status()
+	if err != nil {
+		t.Errorf("unexpected status error: %v", err)
+	}
+
+	if !st.Working {
+		t.Errorf("status working should be true because SQS didn't fail")
+	}
+
+	if len(st.Problems) != 0 {
+		t.Errorf("expected 0 status problems, got: %d: %v", len(st.Problems), st.Problems)
+	}
+}
+
+func Test_PutMessage_Fail(t *testing.T) {
+	fakeErr := errors.New("fake error")
+	s := sqs.NewSink(&mockSink{err: fakeErr})
+
+	err := s.PutMessage(&sqs.Message{})
+	if errors.Cause(err) != fakeErr {
+		t.Errorf("expected fake error, got: %v", err)
+	}
+
+	st, err := s.Status()
+	if err != nil {
+		t.Errorf("unexpected status error: %v", err)
+	}
+
+	if st.Working {
+		t.Errorf("status working should be false because SQS failed")
+	}
+
+	if len(st.Problems) != 1 {
+		t.Errorf("expected 1 status problems, got: %d: %v", len(st.Problems), st.Problems)
+	}
+
+	if st.Problems[0] != fakeErr.Error() {
+		t.Errorf("status problem should be fake error, got: %v", st.Problems[0])
+	}
+}
+
+func Test_PutMessageAlreadyClosed_Fail(t *testing.T) {
+	s := sqs.NewSink(&mockSink{})
+	if err := s.Close(); err != nil {
+		t.Fatalf("unexpected error while closing sink: %v", err)
+	}
+
+	err := s.Close()
+	if err == nil {
+		t.Fatalf("expected error about already closed connection")
+	}
+
+	if !strings.Contains(err.Error(), "Already closed") {
+		t.Errorf("expected Already closed error, got: %v", err)
+	}
+}
+
+type mockMessage struct {
+	err error
+}
+
+func (mm *mockMessage) Marshal() ([]byte, error) {
+	return nil, mm.err
+}
+
+type mockSink struct {
+	err error
+}
+
+func (m *mockSink) SendMessage(pld *string) error {
+	return m.err
+}

--- a/sqs/source.go
+++ b/sqs/source.go
@@ -54,9 +54,8 @@ func (c *Consumer) ConsumeMessages(ctx context.Context, handler pubsub.ConsumerM
 		default:
 			time.Sleep(c.WaitSeconds * time.Second)
 			msgs, err := c.q.ReceiveMessage()
+			c.receiveErr = nil
 
-			// there is no need to set receiveErr to nil before/after an error,
-			// because we are returning the error
 			if err != nil {
 				c.receiveErr = err
 				return err

--- a/sqs/source.go
+++ b/sqs/source.go
@@ -27,6 +27,9 @@ type Consumer struct {
 	queue                  QueueSource
 	deleteAfterConsumption bool  // whether to delete a message after it's successfully processed
 	receiveErr             error // populated when receiving messages from SQS fails
+	// WaitSeconds is the wait time in seconds to wait between API polling requests
+	// Defaults to 0 which effectively disables this.
+	WaitSeconds time.Duration
 }
 
 // ConsumerError holds ID of failed message to process
@@ -52,6 +55,7 @@ func (c *Consumer) ConsumeMessages(ctx context.Context, handler pubsub.ConsumerM
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
+			time.Sleep(c.WaitSeconds * time.Second)
 			msgs, err := c.queue.ReceiveMessage()
 
 			// there is no need to set receiveErr to nil before/after an error,

--- a/sqs/source.go
+++ b/sqs/source.go
@@ -1,0 +1,123 @@
+package sqs
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	pubsub "github.com/utilitywarehouse/go-pubsub"
+)
+
+// Message is the structure of an SQS Message
+type Message struct {
+	Type             string     `json:"Type"`
+	MessageID        string     `json:"MessageId"`
+	TopicArn         string     `json:"TopicArn"`
+	Subject          string     `json:"Subject"`
+	Message          string     `json:"Message"`
+	Timestamp        *time.Time `json:"Timestamp"`
+	SignatureVersion string     `json:"SignatureVersion"`
+	Signature        string     `json:"Signature"`
+	SigningCertURL   string     `json:"SigningCertURL"`
+	UnsubscribeURL   string     `json:"UnsubscribeURL"`
+}
+
+// Consumer polls messages from SQS
+type Consumer struct {
+	queue                  QueueSource
+	deleteAfterConsumption bool  // whether to delete a message after it's successfully processed
+	receiveErr             error // populated when receiving messages from SQS fails
+}
+
+// ConsumerError holds ID of failed message to process
+type ConsumerError struct {
+	MsgID string
+	Value error
+}
+
+// NewConsumer returns a new instance of SQS Consumer.
+func NewConsumer(queue QueueSource) *Consumer {
+	return &Consumer{
+		queue: queue,
+		deleteAfterConsumption: true,
+	}
+}
+
+// ConsumeMessages polls messages from SQS
+func (c *Consumer) ConsumeMessages(ctx context.Context, handler pubsub.ConsumerMessageHandler,
+	onError pubsub.ConsumerErrorHandler) error {
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			msgs, err := c.queue.ReceiveMessage()
+
+			// there is no need to set receiveErr to nil before/after an error,
+			// because we are returning the error
+			if err != nil {
+				c.receiveErr = err
+				return err
+			}
+
+			for _, msg := range msgs {
+				consumerMsg := pubsub.ConsumerMessage{Data: []byte(*msg.Body)}
+
+				if err := handler(consumerMsg); err != nil {
+					msgErr := ConsumerError{
+						MsgID: *msg.MessageId,
+						Value: err,
+					}
+
+					if innerErr := onError(consumerMsg, &msgErr); innerErr != nil {
+						return innerErr
+					}
+				}
+
+				if !c.deleteAfterConsumption {
+					continue
+				}
+
+				// once the message has been successfully consumed, we can delete it
+				if err := c.queue.DeleteMessage(msg.ReceiptHandle); err != nil {
+					return errors.Wrap(err, "failed to delete SQS message")
+				}
+			}
+		}
+	}
+}
+
+// SetDeleteAfterConsumption sets the value of deleteAfterConsumption.
+func (c *Consumer) SetDeleteAfterConsumption(v bool) {
+	c.deleteAfterConsumption = v
+}
+
+// GetDeleteAfterConsumption returns the value of deleteAfterConsumption.
+func (c *Consumer) GetDeleteAfterConsumption() bool {
+	return c.deleteAfterConsumption
+}
+
+// Error method satisfies Error interface of standard library for ConsumerError struct.
+func (e *ConsumerError) Error() string {
+	return e.Value.Error()
+}
+
+// Status method is used to understand if the service is healthy or not.
+// In order to prevent making unnecessary API requests to AWS we rely on
+// sqs.ReceiveMessage error to set `receiveErr` field in Consumer.
+func (c *Consumer) Status() (*pubsub.Status, error) {
+	s := pubsub.Status{Working: true}
+
+	if c.receiveErr != nil {
+		s.Working = false
+		s.Problems = append(s.Problems, c.receiveErr.Error())
+	}
+
+	return &s, nil
+}
+
+// Marshal marshals sqs.Message.Message to []byte.
+func (m *Message) Marshal() ([]byte, error) {
+	return []byte(m.Message), nil
+}

--- a/sqs/source_test.go
+++ b/sqs/source_test.go
@@ -1,0 +1,272 @@
+package sqs_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/pkg/errors"
+	pubsub "github.com/utilitywarehouse/go-pubsub"
+	pubSQS "github.com/utilitywarehouse/go-pubsub/sqs"
+)
+
+// context canceled
+func Test_ConsumeMessagesCtxCancelled_Fail(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	handler := func(pubsub.ConsumerMessage) error { return nil }
+	errHandler := func(pubsub.ConsumerMessage, error) error { return nil }
+
+	timer := time.NewTimer(10 * time.Millisecond)
+	go func() {
+		<-timer.C
+		cancel()
+	}()
+
+	c := pubSQS.NewConsumer(&mockQueue{})
+	err := c.ConsumeMessages(ctx, handler, errHandler)
+
+	if err == nil {
+		t.Error("expected context cancelation error, got <nil>")
+	}
+
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("expected context cancelation error, got: %v", err)
+	}
+}
+
+// failed to receive messages, working = false, and 1st problem matches fake error
+func Test_ConsumeMessages_Fail(t *testing.T) {
+	ctx := context.Background()
+	handler := func(pubsub.ConsumerMessage) error { return nil }
+	errHandler := func(pubsub.ConsumerMessage, error) error { return nil }
+
+	fakeErr := errors.New("failed to connect to SQS")
+	c := pubSQS.NewConsumer(&mockQueue{receiveErr: fakeErr})
+	err := c.ConsumeMessages(ctx, handler, errHandler)
+
+	if errors.Cause(err) != fakeErr {
+		t.Errorf("expected fake error, got: %v", err)
+	}
+
+	st, err := c.Status()
+	if err != nil {
+		t.Fatalf("unexpected error while trying to get status: %v", err)
+	}
+
+	if st.Working {
+		t.Errorf("expected status to be not working")
+	}
+
+	if len(st.Problems) != 1 {
+		t.Fatalf("expected 1 status problem, got: %d: %v", len(st.Problems), st.Problems)
+	}
+
+	if st.Problems[0] != fakeErr.Error() {
+		t.Fatalf("expected 1st problem to be a fake error when polling, got: %v", st.Problems[0])
+	}
+}
+
+// handler and onError fails
+func Test_ConsumeMessages_Handler_Fail(t *testing.T) {
+	ctx := context.Background()
+	handler := func(pubsub.ConsumerMessage) error { return errors.New("could not handle message") }
+	fakeErr := errors.New("error handler returned fake error")
+	errHandler := func(pubsub.ConsumerMessage, error) error { return fakeErr }
+
+	var msgs []*sqs.Message
+	msgID, pld := "12345", "some payload for sqs"
+	msg := sqs.Message{
+		MessageId: &msgID,
+		Body:      &pld,
+	}
+	msgs = append(msgs, &msg)
+
+	c := pubSQS.NewConsumer(&mockQueue{messages: msgs})
+	err := c.ConsumeMessages(ctx, handler, errHandler)
+
+	if errors.Cause(err) != fakeErr {
+		t.Errorf("expected fake error, got: %v", err)
+	}
+
+	st, err := c.Status()
+	if err != nil {
+		t.Fatalf("unexpected error while trying to get status: %v", err)
+	}
+
+	if !st.Working {
+		t.Errorf("expected status to be working")
+	}
+
+	if len(st.Problems) != 0 {
+		t.Fatalf("expected 0 status problem, got: %d: %v", len(st.Problems), st.Problems)
+	}
+}
+
+// handler succeeds, message deletion is skipped and context is cancelled
+func Test_ConsumeMessages_SkipDeleteMessage_Fail(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	handler := func(pubsub.ConsumerMessage) error { return nil }
+	errHandler := func(pubsub.ConsumerMessage, error) error { return nil }
+
+	var msgs []*sqs.Message
+	msgID, pld := "12345", "some payload for sqs"
+	msg := sqs.Message{
+		MessageId: &msgID,
+		Body:      &pld,
+	}
+	msgs = append(msgs, &msg)
+
+	timer := time.NewTimer(10 * time.Millisecond)
+	go func() {
+		<-timer.C
+		cancel()
+	}()
+
+	q := mockQueue{
+		messages:  msgs,
+		deleteErr: errors.New("delete message was not supposed to be called on this test"),
+	}
+
+	c := pubSQS.NewConsumer(&q)
+	c.SetDeleteAfterConsumption(false)
+	if c.GetDeleteAfterConsumption() != false {
+		t.Fatalf("expected `deleteAfterConsumption` flag to be false")
+	}
+
+	err := c.ConsumeMessages(ctx, handler, errHandler)
+
+	if err == nil {
+		t.Fatal("expected cancelation error, got <nil>")
+	}
+
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("expected cancelation error, got: %v", err)
+	}
+
+	st, err := c.Status()
+	if err != nil {
+		t.Fatalf("unexpected error while trying to get status: %v", err)
+	}
+
+	if !st.Working {
+		t.Errorf("expected status to be working")
+	}
+
+	if len(st.Problems) != 0 {
+		t.Fatalf("expected 0 status problem, got: %d: %v", len(st.Problems), st.Problems)
+	}
+}
+
+// handler succeeds, message fails to be deleted
+func Test_ConsumeMessages_DeleteMessage_Fail(t *testing.T) {
+	ctx := context.Background()
+	handler := func(pubsub.ConsumerMessage) error { return nil }
+	errHandler := func(pubsub.ConsumerMessage, error) error { return nil }
+
+	var msgs []*sqs.Message
+	msgID, pld := "12345", "some payload for sqs"
+	msg := sqs.Message{
+		MessageId: &msgID,
+		Body:      &pld,
+	}
+	msgs = append(msgs, &msg)
+
+	fakeErr := errors.New("couldn't delete message")
+	q := mockQueue{
+		messages:  msgs,
+		deleteErr: fakeErr,
+	}
+
+	c := pubSQS.NewConsumer(&q)
+	c.SetDeleteAfterConsumption(true)
+	err := c.ConsumeMessages(ctx, handler, errHandler)
+
+	if err == nil {
+		t.Fatal("expected message deletion error, got <nil>")
+	}
+
+	if errors.Cause(err) != fakeErr {
+		t.Errorf("expected sqs response error, got: %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "failed to delete SQS message") {
+		t.Errorf("expected message deletion error, got: %v", err)
+	}
+
+	st, err := c.Status()
+	if err != nil {
+		t.Fatalf("unexpected error while trying to get status: %v", err)
+	}
+
+	// when we fail to delete a message we do not degrade status
+	if !st.Working {
+		t.Errorf("expected status to be working")
+	}
+
+	if len(st.Problems) != 0 {
+		t.Fatalf("expected 0 status problem, got: %d: %v", len(st.Problems), st.Problems)
+	}
+}
+
+// handler succeeds, message is deleted successfully
+func Test_ConsumeMessages_DeleteMessage_Success(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	handler := func(pubsub.ConsumerMessage) error { return nil }
+	errHandler := func(pubsub.ConsumerMessage, error) error { return nil }
+
+	var msgs []*sqs.Message
+	msgID, pld := "12345", "some payload for sqs"
+	msg := sqs.Message{
+		MessageId: &msgID,
+		Body:      &pld,
+	}
+	msgs = append(msgs, &msg)
+
+	timer := time.NewTimer(time.Millisecond)
+	go func() {
+		<-timer.C
+		cancel()
+	}()
+
+	q := mockQueue{messages: msgs}
+	c := pubSQS.NewConsumer(&q)
+	c.SetDeleteAfterConsumption(true)
+	err := c.ConsumeMessages(ctx, handler, errHandler)
+
+	if err == nil {
+		t.Fatal("expected cancelation error, got <nil>")
+	}
+
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("expected cancelation error, got: %v", err)
+	}
+
+	st, err := c.Status()
+	if err != nil {
+		t.Fatalf("unexpected error while trying to get status: %v", err)
+	}
+
+	if !st.Working {
+		t.Errorf("expected status to be working")
+	}
+
+	if len(st.Problems) != 0 {
+		t.Fatalf("expected 0 status problem, got: %d: %v", len(st.Problems), st.Problems)
+	}
+}
+
+type mockQueue struct {
+	messages   []*sqs.Message
+	receiveErr error
+	deleteErr  error
+}
+
+func (m *mockQueue) ReceiveMessage() ([]*sqs.Message, error) {
+	return m.messages, m.receiveErr
+}
+
+func (m *mockQueue) DeleteMessage(receiptHandle *string) error {
+	return m.deleteErr
+}

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -1,0 +1,92 @@
+package sqs
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+)
+
+// QueueSource interface describes the consumer operations.
+type QueueSource interface {
+	ReceiveMessage() ([]*sqs.Message, error)
+	DeleteMessage(receiptHandle *string) error
+}
+
+// QueueSink describes message publishing method.
+type QueueSink interface {
+	SendMessage(payload *string) error
+}
+
+// SourceQueue holds dependencies to poll for messages.
+type SourceQueue struct {
+	queueURL string // AWS queue URL
+	sqs      *sqs.SQS
+	input    *sqs.ReceiveMessageInput
+}
+
+// SinkQueue holds dependencies to sink messages.
+type SinkQueue struct {
+	queueURL string // AWS queue URL
+	sqs      *sqs.SQS
+	input    *sqs.SendMessageInput
+}
+
+// NewConsumerQueue returns a new SQS consumer
+func NewConsumerQueue(awsAccessKey, awsSecretKey, awsRegion, queueURL string) *SourceQueue {
+	creds := credentials.NewStaticCredentials(awsAccessKey, awsSecretKey, "")
+	sqsInstance := sqs.New(session.Must(session.NewSession()), aws.NewConfig().WithCredentials(creds).WithRegion(awsRegion))
+
+	return &SourceQueue{
+		queueURL: queueURL,
+		sqs:      sqsInstance,
+		input: &sqs.ReceiveMessageInput{
+			QueueUrl:            aws.String(queueURL),
+			AttributeNames:      aws.StringSlice([]string{"All"}),
+			MaxNumberOfMessages: aws.Int64(10),
+		},
+	}
+}
+
+// ReceiveMessage returns a []*sqs.Message or an error if the operation fails.
+func (s *SourceQueue) ReceiveMessage() ([]*sqs.Message, error) {
+	output, err := s.sqs.ReceiveMessage(s.input)
+	if err != nil {
+		return nil, err
+	}
+
+	return output.Messages, nil
+}
+
+// DeleteMessage uses the provided receiptHandle identifier (returned after consuming a message)
+// and makes a delete request to AWS SQS.
+func (s *SourceQueue) DeleteMessage(receiptHandle *string) error {
+	_, err := s.sqs.DeleteMessage(&sqs.DeleteMessageInput{
+		QueueUrl:      aws.String(s.queueURL),
+		ReceiptHandle: receiptHandle,
+	})
+
+	return err
+}
+
+// NewSinkQueue returns a pointer to a new Sink instance.
+func NewSinkQueue(awsAccessKey, awsSecretKey, awsRegion, queueURL string) QueueSink {
+	creds := credentials.NewStaticCredentials(awsAccessKey, awsSecretKey, "")
+	sqsInstance := sqs.New(session.Must(session.NewSession()), aws.NewConfig().WithCredentials(creds).WithRegion(awsRegion))
+
+	return &SinkQueue{
+		queueURL: queueURL,
+		sqs:      sqsInstance,
+		input:    &sqs.SendMessageInput{QueueUrl: &queueURL},
+	}
+}
+
+// SendMessage sinks message in SQS.
+func (s *SinkQueue) SendMessage(payload *string) error {
+	input := s.input
+	input.MessageBody = payload
+
+	_, err := s.sqs.SendMessage(input)
+
+	return err
+}

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -2,9 +2,8 @@ package sqs
 
 import awsSQS "github.com/aws/aws-sdk-go/service/sqs"
 
-// Queue interface is used in order to be able to mock SQS client in unit tests and has
-// the same signature as the methods in aws-sdk-go. Interface holds only the messages
-// we're interested in pubsub.
+// Queue interface has the same signature as the methods in SQS struct in aws-sdk-go.
+// Holds only the messages we're interested in pubsub.
 type Queue interface {
 	ReceiveMessage(*awsSQS.ReceiveMessageInput) (*awsSQS.ReceiveMessageOutput, error)
 	DeleteMessage(*awsSQS.DeleteMessageInput) (*awsSQS.DeleteMessageOutput, error)

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -1,65 +1,12 @@
 package sqs
 
-import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/service/sqs"
-)
+import awsSQS "github.com/aws/aws-sdk-go/service/sqs"
 
-type queue interface {
-	ReceiveMessage() ([]*sqs.Message, error)
-	DeleteMessage(receiptHandle *string) error
-	SendMessage(payload *string) error
-}
-
-type sqsQueue struct {
-	client       *sqs.SQS
-	receiveInput *sqs.ReceiveMessageInput
-	sendInput    *sqs.SendMessageInput
-	deleteInput  *sqs.DeleteMessageInput
-}
-
-// NewQueue returns a new SQS queue
-func NewQueue(p client.ConfigProvider, config *aws.Config, queueURL string) queue {
-	return &sqsQueue{
-		client: sqs.New(p, config),
-		receiveInput: &sqs.ReceiveMessageInput{
-			QueueUrl:            aws.String(queueURL),
-			AttributeNames:      aws.StringSlice([]string{"All"}),
-			MaxNumberOfMessages: aws.Int64(1),
-		},
-		sendInput:   &sqs.SendMessageInput{QueueUrl: &queueURL},
-		deleteInput: &sqs.DeleteMessageInput{QueueUrl: aws.String(queueURL)},
-	}
-}
-
-// ReceiveMessage returns a []*sqs.Message or an error if the operation fails.
-func (s *sqsQueue) ReceiveMessage() ([]*sqs.Message, error) {
-	output, err := s.client.ReceiveMessage(s.receiveInput)
-	if err != nil {
-		return nil, err
-	}
-
-	return output.Messages, nil
-}
-
-// DeleteMessage uses the provided receiptHandle identifier (returned after consuming a message)
-// and makes a delete request to AWS SQS.
-func (s *sqsQueue) DeleteMessage(receiptHandle *string) error {
-	input := s.deleteInput
-	input.ReceiptHandle = receiptHandle
-
-	_, err := s.client.DeleteMessage(input)
-
-	return err
-}
-
-// SendMessage sinks message in SQS.
-func (s *sqsQueue) SendMessage(payload *string) error {
-	input := s.sendInput
-	input.MessageBody = payload
-
-	_, err := s.client.SendMessage(input)
-
-	return err
+// Queue interface is used in order to be able to mock SQS client in unit tests and has
+// the same signature as the methods in aws-sdk-go. Interface holds only the messages
+// we're interested in pubsub.
+type Queue interface {
+	ReceiveMessage(*awsSQS.ReceiveMessageInput) (*awsSQS.ReceiveMessageOutput, error)
+	DeleteMessage(*awsSQS.DeleteMessageInput) (*awsSQS.DeleteMessageOutput, error)
+	SendMessage(*awsSQS.SendMessageInput) (*awsSQS.SendMessageOutput, error)
 }


### PR DESCRIPTION
Satisfies the interfaces `MessageSink` and `MessageSource`.

I've added a configurable `time.Sleep` in polling (`sqs/source.go`) to avoid doing a huge amount of API requests.