### PR TITLE
Update status for NATS streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Current implementations and their status
 | Mock (in memory testing implementation)  | incomplete    |
 | Apache Kafka                             | beta          |
 | Nats                                     | incomplete    |
-| Nats (streaming)                         | incomplete    |
+| Nats streaming                           | beta          |
 | AMQP                                     | incomplete    |
 | AWS SQS                                  | beta          |
 


### PR DESCRIPTION
It in use and API is not changing, so let's call it beta.