### PR TITLE
Change kafka status timeout to 5s

### DIFF
--- a/kafka/status.go
+++ b/kafka/status.go
@@ -13,7 +13,7 @@ func status(brokers []string) (*pubsub.Status, error) {
 
 	for _, broker := range brokers {
 		go func(broker string) {
-			conn, err := net.DialTimeout("tcp", broker, 10*time.Second)
+			conn, err := net.DialTimeout("tcp", broker, 5*time.Second)
 			if err != nil {
 				errs <- fmt.Errorf("Failed to connect to broker %s: %v", broker, err)
 				return


### PR DESCRIPTION
Currently a lot of our kubernetes-manifests has set health check timeout to 10s, which makes all the services that use this check fail due to kubernetes timeout, which hits before Dial timeout:
```
 Readiness probe failed: Get http://10.2.11.186:8080/__/ready: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

