### PR TITLE
add consumer to FailedConsumerMessage

### DIFF
--- a/consumer/deadletter/deadletter.go
+++ b/consumer/deadletter/deadletter.go
@@ -10,34 +10,34 @@ import (
 
 // FailedConsumerMessage a struct for storing failed consumer messages
 type FailedConsumerMessage struct {
-	Message       []byte    `json:"message"`
-	MessageTopic  string    `json:"messageTopic"`
-	ConsumerGroup string    `json:"consumerGroup"`
-	Err           string    `json:"error"`
-	Timestamp     time.Time `json:"timestamp"`
+	Message      []byte    `json:"message"`
+	MessageTopic string    `json:"messageTopic"`
+	Consumer     string    `json:"consumer"`
+	Err          string    `json:"error"`
+	Timestamp    time.Time `json:"timestamp"`
 }
 
 // New returns a new ConsumerErrorHandler which produces JSON serialized FailedConsumerMessage to sink
-func New(sink pubsub.MessageSink, messageTopic string, consumerGroup string) pubsub.ConsumerErrorHandler {
+func New(sink pubsub.MessageSink, messageTopic string, consumer string) pubsub.ConsumerErrorHandler {
 	return NewWithFallback(
 		sink,
 		func(msg pubsub.ConsumerMessage, err error) error {
 			return err
 		},
 		messageTopic,
-		consumerGroup,
+		consumer,
 	)
 }
 
 // NewWithFallback returns a new ConsumerErrorHandler which produces JSON serialized FailedConsumerMessage to sink with fallback handler
-func NewWithFallback(sink pubsub.MessageSink, errHandler pubsub.ConsumerErrorHandler, messageTopic string, consumerGroup string) pubsub.ConsumerErrorHandler {
+func NewWithFallback(sink pubsub.MessageSink, errHandler pubsub.ConsumerErrorHandler, messageTopic string, consumer string) pubsub.ConsumerErrorHandler {
 	return func(msg pubsub.ConsumerMessage, err error) error {
 		failedMsg := FailedConsumerMessage{
-			Message:       msg.Data,
-			MessageTopic:  messageTopic,
-			ConsumerGroup: consumerGroup,
-			Err:           err.Error(),
-			Timestamp:     time.Now(),
+			Message:      msg.Data,
+			MessageTopic: messageTopic,
+			Consumer:     consumer,
+			Err:          err.Error(),
+			Timestamp:    time.Now(),
 		}
 		failedMsgJSON, err := json.Marshal(failedMsg)
 		if err != nil {

--- a/consumer/deadletter/deadletter.go
+++ b/consumer/deadletter/deadletter.go
@@ -10,31 +10,34 @@ import (
 
 // FailedConsumerMessage a struct for storing failed consumer messages
 type FailedConsumerMessage struct {
-	Message      []byte    `json:"message"`
-	MessageTopic string    `json:"messageTopic"`
-	Err          string    `json:"error"`
-	Timestamp    time.Time `json:"timestamp"`
+	Message       []byte    `json:"message"`
+	MessageTopic  string    `json:"messageTopic"`
+	ConsumerGroup string    `json:"consumerGroup"`
+	Err           string    `json:"error"`
+	Timestamp     time.Time `json:"timestamp"`
 }
 
 // New returns a new ConsumerErrorHandler which produces JSON serialized FailedConsumerMessage to sink
-func New(sink pubsub.MessageSink, messageTopic string) pubsub.ConsumerErrorHandler {
+func New(sink pubsub.MessageSink, messageTopic string, consumerGroup string) pubsub.ConsumerErrorHandler {
 	return NewWithFallback(
 		sink,
 		func(msg pubsub.ConsumerMessage, err error) error {
 			return err
 		},
 		messageTopic,
+		consumerGroup,
 	)
 }
 
 // NewWithFallback returns a new ConsumerErrorHandler which produces JSON serialized FailedConsumerMessage to sink with fallback handler
-func NewWithFallback(sink pubsub.MessageSink, errHandler pubsub.ConsumerErrorHandler, messageTopic string) pubsub.ConsumerErrorHandler {
+func NewWithFallback(sink pubsub.MessageSink, errHandler pubsub.ConsumerErrorHandler, messageTopic string, consumerGroup string) pubsub.ConsumerErrorHandler {
 	return func(msg pubsub.ConsumerMessage, err error) error {
 		failedMsg := FailedConsumerMessage{
-			Message:      msg.Data,
-			MessageTopic: messageTopic,
-			Err:          err.Error(),
-			Timestamp:    time.Now(),
+			Message:       msg.Data,
+			MessageTopic:  messageTopic,
+			ConsumerGroup: consumerGroup,
+			Err:           err.Error(),
+			Timestamp:     time.Now(),
 		}
 		failedMsgJSON, err := json.Marshal(failedMsg)
 		if err != nil {

--- a/consumer/deadletter/deadletter_test.go
+++ b/consumer/deadletter/deadletter_test.go
@@ -18,6 +18,7 @@ func TestDeadLetter(t *testing.T) {
 	msg := []byte("test")
 	errMsg := "error message"
 	consumerTopic := "consumerTopic"
+	consumerGroup := "consumerGroup"
 
 	err := in.PutMessage(pubsub.SimpleProducerMessage(msg))
 	if err != nil {
@@ -29,7 +30,7 @@ func TestDeadLetter(t *testing.T) {
 		inCancel()
 		return errors.New(errMsg)
 	}
-	dlErrHanlder := pubsub.ConsumerErrorHandler(New(dl, consumerTopic))
+	dlErrHanlder := pubsub.ConsumerErrorHandler(New(dl, consumerTopic, consumerGroup))
 
 	in.ConsumeMessages(inCtx, handler, dlErrHanlder)
 
@@ -56,4 +57,5 @@ func TestDeadLetter(t *testing.T) {
 	assert.Equal(t, fsm.Message, msg)
 	assert.Equal(t, fsm.Err, errMsg)
 	assert.Equal(t, fsm.MessageTopic, consumerTopic)
+	assert.Equal(t, fsm.ConsumerGroup, consumerGroup)
 }

--- a/consumer/deadletter/deadletter_test.go
+++ b/consumer/deadletter/deadletter_test.go
@@ -18,7 +18,7 @@ func TestDeadLetter(t *testing.T) {
 	msg := []byte("test")
 	errMsg := "error message"
 	consumerTopic := "consumerTopic"
-	consumerGroup := "consumerGroup"
+	consumer := "consumer"
 
 	err := in.PutMessage(pubsub.SimpleProducerMessage(msg))
 	if err != nil {
@@ -30,7 +30,7 @@ func TestDeadLetter(t *testing.T) {
 		inCancel()
 		return errors.New(errMsg)
 	}
-	dlErrHanlder := pubsub.ConsumerErrorHandler(New(dl, consumerTopic, consumerGroup))
+	dlErrHanlder := pubsub.ConsumerErrorHandler(New(dl, consumerTopic, consumer))
 
 	in.ConsumeMessages(inCtx, handler, dlErrHanlder)
 
@@ -57,5 +57,5 @@ func TestDeadLetter(t *testing.T) {
 	assert.Equal(t, fsm.Message, msg)
 	assert.Equal(t, fsm.Err, errMsg)
 	assert.Equal(t, fsm.MessageTopic, consumerTopic)
-	assert.Equal(t, fsm.ConsumerGroup, consumerGroup)
+	assert.Equal(t, fsm.Consumer, consumer)
 }


### PR DESCRIPTION
Currently our pattern for splitting topics is per event type which is common and well recognised.

What I'm trying to create here is the ability to ignore events deadlettered by other consumers so the deadletter handlers can focus only on events that pertain to its consumer group while maintaining a degree of separation from the original handlers processing logic.

of course this is only an issue if you apply our current topic splitting pattern to our deadletter topics but the only alternative as I see it is a deadletter per consumer group per original topic. Which I imagine will get very messy very quickly.

The main benefit of including this metadata in the event is granting the ability for the consumers of the deadletter topic to filter out events that its group has not deadlettered, thus lessening the possibility of the scenario where Consumer A deadletters an event while Consumer B processes it successfully followed by Consumer A's deadletter handler re introducing the processed event into its pipe.