### PR TITLE
Allow configuration of Producer.MaxMessageBytes

### DIFF
--- a/kafka/kafkasink.go
+++ b/kafka/kafkasink.go
@@ -41,7 +41,7 @@ func NewMessageSink(config MessageSinkConfig) (pubsub.MessageSink, error) {
 	conf.Producer.Timeout = time.Duration(60) * time.Second
 
 	if config.MaxMessageBytes != 0 {
-		if config.MaxMessageBytes > sarama.MaxRequestSize {
+		if config.MaxMessageBytes > int(sarama.MaxRequestSize) {
 			sarama.MaxRequestSize = int32(config.MaxMessageBytes)
 		}
 		conf.Producer.MaxMessageBytes = config.MaxMessageBytes

--- a/kafka/kafkasink.go
+++ b/kafka/kafkasink.go
@@ -25,9 +25,10 @@ type messageSink struct {
 }
 
 type MessageSinkConfig struct {
-	Topic   string
-	Brokers []string
-	KeyFunc func(pubsub.ProducerMessage) []byte
+	Topic           string
+	Brokers         []string
+	KeyFunc         func(pubsub.ProducerMessage) []byte
+	MaxMessageBytes *int
 }
 
 func NewMessageSink(config MessageSinkConfig) (pubsub.MessageSink, error) {
@@ -38,6 +39,10 @@ func NewMessageSink(config MessageSinkConfig) (pubsub.MessageSink, error) {
 	conf.Producer.Return.Errors = true
 	conf.Producer.Retry.Max = 3
 	conf.Producer.Timeout = time.Duration(60) * time.Second
+
+	if config.MaxMessageBytes != nil {
+		conf.Producer.MaxMessageBytes = *config.MaxMessageBytes
+	}
 
 	if config.KeyFunc != nil {
 		conf.Producer.Partitioner = sarama.NewHashPartitioner

--- a/kafka/kafkasink.go
+++ b/kafka/kafkasink.go
@@ -28,7 +28,7 @@ type MessageSinkConfig struct {
 	Topic           string
 	Brokers         []string
 	KeyFunc         func(pubsub.ProducerMessage) []byte
-	MaxMessageBytes *int
+	MaxMessageBytes int
 }
 
 func NewMessageSink(config MessageSinkConfig) (pubsub.MessageSink, error) {
@@ -40,8 +40,11 @@ func NewMessageSink(config MessageSinkConfig) (pubsub.MessageSink, error) {
 	conf.Producer.Retry.Max = 3
 	conf.Producer.Timeout = time.Duration(60) * time.Second
 
-	if config.MaxMessageBytes != nil {
-		conf.Producer.MaxMessageBytes = *config.MaxMessageBytes
+	if config.MaxMessageBytes != 0 {
+		if config.MaxMessageBytes > 100*1024*1024 {
+			sarama.MaxRequestSize = int32(config.MaxMessageBytes)
+		}
+		conf.Producer.MaxMessageBytes = config.MaxMessageBytes
 	}
 
 	if config.KeyFunc != nil {

--- a/kafka/kafkasink.go
+++ b/kafka/kafkasink.go
@@ -41,7 +41,7 @@ func NewMessageSink(config MessageSinkConfig) (pubsub.MessageSink, error) {
 	conf.Producer.Timeout = time.Duration(60) * time.Second
 
 	if config.MaxMessageBytes != 0 {
-		if config.MaxMessageBytes > 100*1024*1024 {
+		if config.MaxMessageBytes > sarama.MaxRequestSize {
 			sarama.MaxRequestSize = int32(config.MaxMessageBytes)
 		}
 		conf.Producer.MaxMessageBytes = config.MaxMessageBytes


### PR DESCRIPTION
Allows configuration of MaxMessageBytes on MessageSink

Note changing this value alone will not enable larger messages - max.message.bytes must also be set on topic or broker, and for MaxMessageBytes values of >104857600 , sarama's max request size must also be changed.