### PR TITLE
Fix panic when connection hasn't been established

### DIFF
--- a/natss/source.go
+++ b/natss/source.go
@@ -186,5 +186,8 @@ func (mq *messageSource) ConsumeMessages(ctx context.Context, handler pubsub.Con
 }
 
 func (mq *messageSource) Status() (*pubsub.Status, error) {
+	if mq.conn == nil {
+		return nil, ErrNotConnected
+	}
 	return natsStatus(mq.conn.NatsConn())
 }


### PR DESCRIPTION
The underlying may have failed to be created when the status is called. When the connection fails to be created calling Status() raises a panic, this PR fixes that.