### PR TITLE
adds connectionlost handler for nats streaming

### DIFF
--- a/natss/natssink.go
+++ b/natss/natssink.go
@@ -23,6 +23,8 @@ type connectionState struct {
 	err error
 }
 
+// ErrConnLost is the error created when the underlying nats streaming client
+// has established that the connection to the nats streaming server has been lost
 var ErrConnLost = errors.New("nats streaming connection lost")
 
 type messageSink struct {


### PR DESCRIPTION
this introduces the nats streaming connection lost handler that was
added to nats-streaming in server version 0.10.0 and client version
0.4.0

this will probably need a conversation about graceful upgrades for
existing deployments