### PR TITLE
Add offsets retention minutes setting to control offsets retention by…

### DIFF
--- a/kafka/kafka_test.go
+++ b/kafka/kafka_test.go
@@ -191,7 +191,7 @@ func TestConsumeError(t *testing.T) {
 }
 
 func produceMessage(t *testing.T, topicName, message string) {
-	sink, err := NewMessageSink(MessageSinkConfig{topicName, []string{*broker}, nil})
+	sink, err := NewMessageSink(MessageSinkConfig{Topic: topicName, Brokers: []string{*broker}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kafka/kafkasource.go
+++ b/kafka/kafkasource.go
@@ -23,6 +23,7 @@ type messageSource struct {
 	brokers                  []string
 	offset                   int64
 	metadataRefreshFrequency time.Duration
+	offsetsRetention         time.Duration
 	Version                  *sarama.KafkaVersion
 }
 
@@ -32,6 +33,7 @@ type MessageSourceConfig struct {
 	Brokers                  []string
 	Offset                   int64
 	MetadataRefreshFrequency time.Duration
+	OffsetsRetention         time.Duration
 	Version                  *sarama.KafkaVersion
 }
 
@@ -46,10 +48,11 @@ func NewMessageSource(config MessageSourceConfig) pubsub.MessageSource {
 	}
 
 	return &messageSource{
-		consumergroup: config.ConsumerGroup,
-		topic:         config.Topic,
-		brokers:       config.Brokers,
-		offset:        offset,
+		consumergroup:            config.ConsumerGroup,
+		topic:                    config.Topic,
+		brokers:                  config.Brokers,
+		offset:                   offset,
+		offsetsRetention:         config.OffsetsRetention,
 		metadataRefreshFrequency: mrf,
 		Version:                  config.Version,
 	}
@@ -60,6 +63,7 @@ func (mq *messageSource) ConsumeMessages(ctx context.Context, handler pubsub.Con
 	config.Consumer.Return.Errors = true
 	config.Consumer.Offsets.Initial = mq.offset
 	config.Metadata.RefreshFrequency = mq.metadataRefreshFrequency
+	config.Consumer.Offsets.Retention = mq.offsetsRetention
 
 	if mq.Version != nil {
 		config.Version = *mq.Version


### PR DESCRIPTION
… consumer group

In energy, some consumer groups don't receive messages for a very long time.  We've already bumped offsets.retention.minutes for the cluster, but would like to bump this setting further on a per consumer group basis.