### PR TITLE
Disable rcrowley metrics by default for kafka sink & source

### DIFF
--- a/kafka/init.go
+++ b/kafka/init.go
@@ -1,0 +1,8 @@
+package kafka
+
+import "github.com/rcrowley/go-metrics"
+
+func init() {
+	// Disable rcrowley/go-metrics by default due to memory leak in this lib which is used by Shopify/sarama
+	metrics.UseNilMetrics = true
+}


### PR DESCRIPTION
as per https://utilitywarehouse.slack.com/archives/C34E9HEGG/p1537798450000100
THis will disable leaky `rcrowley/go-metrics`