### PR TITLE
Fix instrumented pubsub initialize counters with 0

### DIFF
--- a/instrumented/instrumented_pubsub.go
+++ b/instrumented/instrumented_pubsub.go
@@ -40,6 +40,9 @@ func NewMessageSource(
 			panic(err)
 		}
 	}
+	counter.WithLabelValues("error", topic).Add(0)
+	counter.WithLabelValues("success", topic).Add(0)
+
 	return &MessageSource{source, counter, topic}
 }
 


### PR DESCRIPTION
If you don't have any errors there will be no `messages_consumed_total{status="error",...}` metric, which is annoying it deal with.

Prometheus best pratices recommend to avoid missing metrics:

https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics
https://www.robustperception.io/existential-issues-with-metrics