### PR TITLE
fix: nil pointer reference

### DIFF
--- a/kafka/kafkasource.go
+++ b/kafka/kafkasource.go
@@ -155,6 +155,9 @@ func newConcurrentMessageHandler(ctx context.Context,
 		for {
 			select {
 			case msg := <- part.Messages():
+				if msg == nil {
+					continue
+				}
 				message := pubsub.ConsumerMessage{Data: msg.Value}
 				err := handler(message)
 				if err != nil {


### PR DESCRIPTION
fixes an issue with the Kafka concurrent message handler attempting to
handle a nil pointer as a message when the channel is closing