### PR TITLE
fix: nil pointer handler in concurrent Kafka handler

### DIFF
--- a/kafka/kafkasource.go
+++ b/kafka/kafkasource.go
@@ -130,12 +130,12 @@ func (mq *messageSource) ConsumeMessagesConcurrently(ctx context.Context, handle
 	for {
 		select {
 		case part, ok := <-c.Partitions():
-			if !ok {
-				return nil
-			}
-			if part != nil {
-				// partitions will emit a nil pointer when the parent chanel is tombed  as
-				// the client is closed
+			// partitions will emit a nil pointer (part) when the parent channel is tombed as
+			// the client is closed. ok will be false when the partitions channel is closed
+			// in both cases we want to wait for the errgroup to handle any errors correctly and
+			// gracefully close the subroutines. If either the part is nil or ok is false then
+			// we simply ignore it to give the errgroup and subroutines time to finish
+			if ok && part != nil {
 				pGroup.Go(newConcurrentMessageHandler(pContext, c, part, handler, onError))
 			}
 		case err := <-c.Errors():

--- a/kafka/kafkasource.go
+++ b/kafka/kafkasource.go
@@ -133,7 +133,11 @@ func (mq *messageSource) ConsumeMessagesConcurrently(ctx context.Context, handle
 			if !ok {
 				return nil
 			}
-			pGroup.Go(newConcurrentMessageHandler(pContext, c, part, handler, onError))
+			if part != nil {
+				// partitions will emit a nil pointer when the parent chanel is tombed  as
+				// the client is closed
+				pGroup.Go(newConcurrentMessageHandler(pContext, c, part, handler, onError))
+			}
 		case err := <-c.Errors():
 			pGroup.Wait()
 			return err


### PR DESCRIPTION
fixes a nil ponter that occures due to the way that the sarama-cluster
handles partition closure internally